### PR TITLE
Update to latest version of Redis dependency.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,6 +18,6 @@ path = "examples/example.rs"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-rand = "0.8.3"
-redis = "0.20.0"
+rand = "0.8"
+redis = "0.23"
 thiserror = "1.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "redsync"
-version = "1.0.0"
+version = "1.0.1"
 authors = ["jace-ys <jaceys.tan@gmail.com>"]
 edition = "2018"
 description = "A Rust implementation of Redlock for distributed locks with Redis"


### PR DESCRIPTION
A warning message has started being generated about the old version of `redis` currently specified with this repository.

```
warning: the following packages contain code that will be rejected by a future version of Rust: redis v0.20.2
```

I left the patch version number off so that the latest patch version will automatically be used.

Thanks for this crate!